### PR TITLE
Disables text selection for all SVG and disables all interaction with text on the fatality rate chart.

### DIFF
--- a/main.css
+++ b/main.css
@@ -91,3 +91,21 @@ footer{
 }
 #explanation {
 }
+
+/* This disables text selection for all SVG text entities */
+svg text {
+  cursor: default;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+svg text::selection {
+  background: none;
+}
+
+/* This disables text interaction for the case fatality rate chart */
+#chart svg text{
+  pointer-events: none;
+}
+


### PR DESCRIPTION
- Also avoids text interaction for the case fatality rate chart.
- Disables text selection for all SVG text entities.

This should make hovering over the visual elements easier.