### PR TITLE
Adding Bar Chart Race & Redirecting Observable Notebook Source to Professor YY's 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# COVID-19 Trend Visualizations Website Source
+
+This repository contains the source codes of [COVID-19 Trend Visualizations](https://yyahn.com/covid19/).
+

--- a/contributors.html
+++ b/contributors.html
@@ -23,7 +23,7 @@
             <a href="fatality.html">Fatality</a>
             <a href="racing.html">Racing</a>
             <div class="bottom">
-            <a href="Contributors.html">Contributors</a>
+            <a href="contributors.html">Contributors</a>
             </div>
           </div>
     </aside>

--- a/contributors.html
+++ b/contributors.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-46647600-3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-46647600-3');
+    </script>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  	<title>Coronavirus Trend Visualization</title>
+    <link rel="stylesheet" type="text/css" href="main.css">
+  </head>
+  <body>
+    <aside>
+      <div id="sidebar">
+          <div style="margin-top: 100px"></div>
+            <a href="index.html">Trend</a>
+            <a href="trajectory.html">Trajectory</a>
+            <a href="fatality.html">Fatality</a>
+            <a href="racing.html">Racing</a>
+            <div class="bottom">
+            <a href="Contributors.html">Contributors</a>
+            </div>
+          </div>
+    </aside>
+
+   <div id="wrapper">
+    <header>
+      <h1>COVID-19 Trend Visualizations</h1>
+    </header>
+
+    <div id="contributor">
+      <a class="anchor" name="h2contribute"></a>
+      <h2>Contributors</h2>
+      <div id="explanation">
+      <p>These visualizations are created by <a href="https://yongyeol.com/">YY Ahn</a> (<a href="https://twitter.com/yy">@yy</a>), <a href="https://www.linkedin.com/in/sina-kianersi-b311b3b1/">Sina Kianersi</a> (<a href="https://twitter.com/sina_kianersi">@sina_kianersi</a>), and <a href="https://hongtaoh.com/">Hongtao Hao</a> at the <a href="https://www.indiana.edu">Indiana University Bloomington</a>. The visualization of <a href="fatality.html">Fatality</a> is built on <a href="https://observablehq.com/@mbostock/the-wealth-health-of-nations">the recreation of GapMinder visualization</a> by <a href="https://observablehq.com/@mbostock">@mbostock</a>.</p>
+
+      <ul>
+        <li>Contributors: <a href="https://observablehq.com/@hongtaoh">@hongtaoh</a>, <a href="https://twitter.com/alphastanley">@alphastanley</a></li>
+        <li>You can check out the source code on ObservableHQ: <a href="https://observablehq.com/@yy/covid-19-spreading-trends">Spreading trends</a>, <a href="https://observablehq.com/@yy/covid-19-fatality-rate">Case fatlity rate</a>, <a href="https://observablehq.com/@yy/covid-19-confirmed-vs-new-cases">Trejectory of confirmed and new cases</a>, and <a href="https://observablehq.com/@hongtaoh/bar-chart-race-of-coronavirus-confirmed-cases">Bar chart rase of confirmed cases</a></li>
+        <li>Data and workflow: <a href="https://github.com/yy/covid19-data">https://github.com/yy/covid19-data</a></li>
+      </ul>
+      </div>
+    </div>
+  </div>
+  </body>
+</html>

--- a/fatality.html
+++ b/fatality.html
@@ -23,7 +23,7 @@
             <a href="fatality.html">Fatality</a>
             <a href="racing.html">Racing</a>
             <div class="bottom">
-            <a href="Contributors.html">Contributors</a>
+            <a href="contributors.html">Contributors</a>
             </div>
           </div>
     </aside>

--- a/fatality.html
+++ b/fatality.html
@@ -21,6 +21,10 @@
             <a href="index.html">Trend</a>
             <a href="trajectory.html">Trajectory</a>
             <a href="fatality.html">Fatality</a>
+            <a href="racing.html">Racing</a>
+            <div class="bottom">
+            <a href="Contributors.html">Contributors</a>
+            </div>
           </div>
     </aside>
 
@@ -63,7 +67,7 @@
   	<script type="module">
       import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
 
-      import notebookFatality from "https://api.observablehq.com/d/945cb14c5e8290a8.js?v=3";
+      import notebookFatality from "https://api.observablehq.com/@yy/covid-19-fatality-rate.js?v=3";
       const rensersFatality = {
         "viewof delay_parameter": "#viewof-delay_parameter",
         "viewof timeSliderFatality": "#viewof-timeSliderFatality",

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
             <a href="index.html">Trend</a>
             <a href="trajectory.html">Trajectory</a>
             <a href="fatality.html">Fatality</a>
+            <a href="racing.html">Racing</a>
+            <div class="bottom">
+            <a href="Contributors.html">Contributors</a>
+            </div>
           </div>
     </aside>
 
@@ -40,6 +44,7 @@
       </div> 
       <div id="viewof-selected_regions" class="viewof"></div>
       <div id="viewof-y_type" class="viewof"></div>
+      <div id="viewof-goback" class="viewof"></div>
       <div id="trend_chart" class="chart"></div>
       <div id="trend_swatch"></div>
       <div id="explanation">
@@ -52,11 +57,12 @@
   	<script type="module">
       import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
 
-      import notebookSpreading from "https://api.observablehq.com/d/4cd98169fdfdd8b3.js?v=3"; 
+      import notebookSpreading from "https://api.observablehq.com/@yy/covid-19-spreading-trends.js?v=3"; 
       const rendersSpreading = {
       	"viewof y_type": "#viewof-y_type",
         "viewof pivot_n": "#viewof-pivot_n",
         "viewof num_days": "#viewof-num_days",
+        "viewof goBack": "#viewof-goback",
         //"viewof doubling_periods": "#viewof-doubling_periods",
         "viewof selected_regions": "#viewof-selected_regions",
         "swatch": "#trend_swatch",

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             <a href="fatality.html">Fatality</a>
             <a href="racing.html">Racing</a>
             <div class="bottom">
-            <a href="Contributors.html">Contributors</a>
+            <a href="contributors.html">Contributors</a>
             </div>
           </div>
     </aside>

--- a/main.css
+++ b/main.css
@@ -21,6 +21,10 @@ header{
   flex: 50%;
 }
 
+.bottom {
+  position: absolute;
+  bottom: 50%;
+}
 
 #sidebar {
   height: 100%;
@@ -65,6 +69,8 @@ a.anchor {
 #trajectory-viz{
 }
 #fatality-viz{
+}
+#racing-viz{
 }
 
 .viewof {

--- a/racing.html
+++ b/racing.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-46647600-3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-46647600-3');
+    </script>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  	<title>Coronavirus Trend Visualization</title>
+    <link rel="stylesheet" type="text/css" href="main.css">
+  </head>
+  <body>
+    <aside>
+      <div id="sidebar">
+          <div style="margin-top: 100px"></div>
+            <a href="index.html">Trend</a>
+            <a href="trajectory.html">Trajectory</a>
+            <a href="fatality.html">Fatality</a>
+            <a href="racing.html">Racing</a>
+            <div class="bottom">
+            <a href="Contributors.html">Contributors</a>
+            </div>
+          </div>
+    </aside>
+
+   <div id="wrapper">
+    <header>
+      <h1>COVID-19 Trend Visualizations</h1>
+    </header>
+
+    <div id="racing-viz">
+      <h2>Bar Chart Race of Confirmed Cases</h2>
+      <div id="viewof-speed" class="viewof"></div>
+      <div id="viewof-replay" class="viewof"></div>
+      <div id="Rchart" class="chart"></div>
+      <div id="explanation">
+      <p>Please allow 5 seconds for the chart to load, since the dataset is very large.</p>
+      <p>This visulization is almost completely based on Mike Bostock's<a href="https://observablehq.com/@d3/bar-chart-race-explained"> Bar Chart Race, Explained</a>, with only a few minor changes. 
+
+      <p>Improve this visualization on ObservableHQ: <a href="https://observablehq.com/@hongtaoh/bar-chart-race-of-coronavirus-confirmed-cases">https://observablehq.com/@hongtaoh/bar-chart-race-of-coronavirus-confirmed-cases</a></p>
+      </div>
+    </div>
+  </div>
+  
+  	<script type="module">
+      import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+
+      import notebook from "https://api.observablehq.com/@hongtaoh/bar-chart-race-of-coronavirus-confirmed-cases.js?v=3"; 
+      const renders = {
+        "viewof playSpeedRacing": "#viewof-speed",
+        "viewof replay": "#viewof-replay",
+        "Rchart": "#Rchart",
+      }
+
+      const runtime = new Runtime();
+      const main = runtime.module(notebook, name => {
+         const selector = renders[name];
+          if (selector) {
+              return new Inspector(document.querySelector(selector));
+          } else {
+              return true;
+          }
+      });
+
+    </script>
+  </body>
+</html>

--- a/racing.html
+++ b/racing.html
@@ -23,7 +23,7 @@
             <a href="fatality.html">Fatality</a>
             <a href="racing.html">Racing</a>
             <div class="bottom">
-            <a href="Contributors.html">Contributors</a>
+            <a href="contributors.html">Contributors</a>
             </div>
           </div>
     </aside>

--- a/trajectory.html
+++ b/trajectory.html
@@ -23,6 +23,10 @@
             <a href="index.html">Trend</a>
             <a href="trajectory.html">Trajectory</a>
             <a href="fatality.html">Fatality</a>
+            <a href="racing.html">Racing</a>
+            <div class="bottom">
+            <a href="Contributors.html">Contributors</a>
+            </div>
           </div>
     </aside>
 
@@ -57,7 +61,7 @@
 
   	<script type="module">
       import {Runtime, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-      import notebookTrajectory from "https://api.observablehq.com/d/87e6003e4f4aab00.js?v=3";
+      import notebookTrajectory from "https://api.observablehq.com/@yy/covid-19-confirmed-vs-new-cases.js?v=3";
       const rensersTrajectory = {
         "viewof yTypeT": "#viewof-yTypeT",
         "viewof timeSliderT": "#viewof-timeSliderT",

--- a/trajectory.html
+++ b/trajectory.html
@@ -25,7 +25,7 @@
             <a href="fatality.html">Fatality</a>
             <a href="racing.html">Racing</a>
             <div class="bottom">
-            <a href="Contributors.html">Contributors</a>
+            <a href="contributors.html">Contributors</a>
             </div>
           </div>
     </aside>


### PR DESCRIPTION
Professor YY:

I added the bar chart race of confirmed cases. It's very crude, as you can see. Maybe I'll improve it when my application is done. I've also redirected the ObservableHQ link to yours. The data sources in all the ObservableHQ notebooks are still my fork of covid-19 data since I need to updated the data everyday manually on my local machine. I hope it's fine. The two data repositories are exactly the same. 

I've also added the page of "Contributors" that was originally in the previous website. 